### PR TITLE
認証画面追加

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,7 +1,10 @@
 "use server";
 
+import { getAuthHeader } from "@/lib/auth";
 import { refresh } from "next/cache";
 import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 const API_BASE = process.env.API_URL ?? "http://localhost:8000";
 
@@ -17,23 +20,26 @@ export const createTrip = async (formData: FormData) => {
   };
   const res = await fetch(`${API_BASE}/trips`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await getAuthHeader()) },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error("Failed to create trip");
+  if (!res.ok) {
+    throw new Error("Failed to create trip");
+  }
   refresh();
 };
 
 export const updateTripStatus = async (id: number, status: "want" | "done") => {
   const res = await fetch(`${API_BASE}/trips/${id}`, {
     method: "PATCH",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await getAuthHeader()) },
     body: JSON.stringify({ status }),
   });
   if (!res.ok) throw new Error("Failed to update trip");
   revalidatePath("/");
 };
 
+// スポットを追加
 export const createSpot = async (tripId: number, formData: FormData) => {
   const body = {
     name: formData.get("name"),
@@ -42,13 +48,14 @@ export const createSpot = async (tripId: number, formData: FormData) => {
   };
   const res = await fetch(`${API_BASE}/trips/${tripId}/spots`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await getAuthHeader()) },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error("Failed to create spot");
   revalidatePath(`/trips/${tripId}`);
 };
 
+// 支出を追加
 export const createExpense = async (tripId: number, formData: FormData) => {
   const body = {
     category: formData.get("category"),
@@ -57,13 +64,14 @@ export const createExpense = async (tripId: number, formData: FormData) => {
   };
   const res = await fetch(`${API_BASE}/trips/${tripId}/expenses`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await getAuthHeader()) },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error("Failed to create expense");
   revalidatePath(`/trips/${tripId}`);
 };
 
+// スポットを更新
 export const updateSpot = async (
   spotId: number,
   tripId: number,
@@ -71,13 +79,14 @@ export const updateSpot = async (
 ) => {
   const res = await fetch(`${API_BASE}/spots/${spotId}`, {
     method: "PATCH",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await getAuthHeader()) },
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error("Failed to update spot");
   revalidatePath(`/trips/${tripId}`);
 };
 
+// 支出を更新
 export const updateExpense = async (
   expenseId: number,
   tripId: number,
@@ -85,37 +94,116 @@ export const updateExpense = async (
 ) => {
   const res = await fetch(`${API_BASE}/expenses/${expenseId}`, {
     method: "PATCH",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await getAuthHeader()) },
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error("Failed to update expense");
   revalidatePath(`/trips/${tripId}`);
 };
 
+// 旅行を削除
 export const deleteTrip = async (id: number) => {
-  const res = await fetch(`${API_BASE}/trips/${id}`, { method: "DELETE" });
+  const res = await fetch(`${API_BASE}/trips/${id}`, {
+    method: "DELETE",
+    headers: await getAuthHeader(),
+  });
   if (!res.ok) throw new Error("Failed to delete trip");
   revalidatePath("/");
 };
 
+// スポットチェックの切り替え
 export const toggleSpotChecked = async (spotId: number, tripId: number) => {
   const res = await fetch(`${API_BASE}/spots/${spotId}/check`, {
     method: "PATCH",
+    headers: await getAuthHeader(),
   });
   if (!res.ok) throw new Error("Failed to toggle spot");
   revalidatePath(`/trips/${tripId}`);
 };
 
+// スポットを削除
 export const deleteSpot = async (spotId: number, tripId: number) => {
-  const res = await fetch(`${API_BASE}/spots/${spotId}`, { method: "DELETE" });
+  const res = await fetch(`${API_BASE}/spots/${spotId}`, {
+    method: "DELETE",
+    headers: await getAuthHeader(),
+  });
   if (!res.ok) throw new Error("Failed to delete spot");
   revalidatePath(`/trips/${tripId}`);
 };
 
+// 支出を削除
 export const deleteExpense = async (expenseId: number, tripId: number) => {
   const res = await fetch(`${API_BASE}/expenses/${expenseId}`, {
     method: "DELETE",
+    headers: await getAuthHeader(),
   });
   if (!res.ok) throw new Error("Failed to delete expense");
   revalidatePath(`/trips/${tripId}`);
+};
+
+// ログイン
+export const login = async (prevState: any, formData: FormData) => {
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+
+  const res = await fetch(`${API_BASE}/auth/login`, {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+    headers: {
+      "Content-Type": "application/json",
+      ...(await getAuthHeader()),
+    },
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    return { status: "error", data: null, error };
+  }
+
+  const { accessToken } = await res.json();
+  const cookieStore = await cookies();
+  cookieStore.set("accessToken", accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 60 * 24 * 7, // 7日間
+    path: "/",
+  });
+
+  redirect("/");
+};
+
+// ユーザ登録
+export const register = async (prevState: any, formData: FormData) => {
+  const body = {
+    username: formData.get("username"),
+    email: formData.get("email") as string,
+    password: formData.get("password") as string,
+  };
+  const res = await fetch(`${API_BASE}/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const error = await res.text();
+    return { status: "error", data: null, error };
+  }
+
+  const { accessToken } = await res.json();
+  const cookieStore = await cookies();
+  cookieStore.set("accessToken", accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 60 * 24 * 7, // 7日間
+    path: "/",
+  });
+
+  redirect("/");
+};
+
+// ログアウト
+export const logout = async () => {
+  const cookieStore = await cookies();
+  cookieStore.delete("accessToken");
+  redirect("/login");
 };

--- a/app/components/LoginForm.tsx
+++ b/app/components/LoginForm.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { login } from "../actions";
+
+const LoginForm = () => {
+  const [state, formAction, pending] = useActionState(login, null);
+
+  useEffect(() => {
+    if (!state) {
+      return;
+    }
+
+    if (state.status === "success") {
+      alert(JSON.stringify(state.data));
+    } else if (state.status === "error") {
+      alert(state.error);
+    }
+  }, [state]);
+
+  return (
+    <>
+      <form action={formAction}>
+        <div className="form-field">
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            disabled={pending}
+          />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            disabled={pending}
+          />
+        </div>
+
+        <button type="submit" disabled={pending} className="submit-button">
+          {pending ? "ログイン中..." : "ログインする"}
+        </button>
+
+        {state?.error && (
+          <div className="error-message">
+            <p>エラーが発生しました：{state.error}</p>
+          </div>
+        )}
+      </form>
+    </>
+  );
+};
+
+export default LoginForm;

--- a/app/components/LoginForm.tsx
+++ b/app/components/LoginForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useActionState, useEffect } from "react";
-import { login } from "../actions";
+import { login } from "@/app/actions";
+import Link from "next/link";
 
 const LoginForm = () => {
   const [state, formAction, pending] = useActionState(login, null);
@@ -19,41 +20,56 @@ const LoginForm = () => {
   }, [state]);
 
   return (
-    <>
-      <form action={formAction}>
-        <div className="form-field">
-          <label htmlFor="email">メールアドレス</label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            required
-            disabled={pending}
-          />
-        </div>
-
-        <div className="form-field">
-          <label htmlFor="password">パスワード</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            required
-            disabled={pending}
-          />
-        </div>
-
-        <button type="submit" disabled={pending} className="submit-button">
-          {pending ? "ログイン中..." : "ログインする"}
-        </button>
-
-        {state?.error && (
-          <div className="error-message">
-            <p>エラーが発生しました：{state.error}</p>
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl w-full max-w-sm p-6 flex flex-col gap-3">
+        <form action={formAction}>
+          <div className="flex flex-col gap-3">
+            <h1 className="flex text-xl font-serif justify-center">ログイン</h1>
+            <div className="flex flex-col">
+              <label htmlFor="email">メールアドレス</label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                disabled={pending}
+                className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+              />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="password">パスワード</label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                disabled={pending}
+                className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+              />
+            </div>
+            <div className="mt-2 flex justify-center">
+              <button
+                type="submit"
+                disabled={pending}
+                className="rounded-lg py-2 px-3 bg-gray-900 text-gray-100 text-lg font-serif shadow-md hover:bg-gray-700 transition-colors duration-300 cursor-pointer"
+              >
+                {pending ? "ログイン中..." : "ログインする"}
+              </button>
+            </div>
+            {state?.error && (
+              <div className="error-message">
+                <p>エラーが発生しました：{state.error}</p>
+              </div>
+            )}
           </div>
-        )}
-      </form>
-    </>
+        </form>
+        <div className="mt-2 flex justify-center">
+          <button className="rounded-lg py-2 px-3 border border-gray-200 text-lg font-serif text-gray-600 hover:bg-gray-50 transition-colors duration-300 cursor-pointer">
+            <Link href={`/register`}>新規登録</Link>
+          </button>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/app/components/LogoutButton.tsx
+++ b/app/components/LogoutButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { logout } from "@/app/actions";
+import { buttonConfig } from "@/app/constants/ui";
+
+export const LogoutButton = () => {
+  return (
+    <form action={logout}>
+      <button
+        type="submit"
+        className="ml-auto px-2 py-1 text-md rounded-md bg-red-500 text-white hover:bg-red-700 transition-colors duration-300 cursor-pointer"
+      >
+        {buttonConfig.logout}
+      </button>
+    </form>
+  );
+};

--- a/app/components/RegisterForm.tsx
+++ b/app/components/RegisterForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useActionState, useEffect } from "react";
-import { register } from "../actions";
+import { register } from "@/app/actions";
+import Link from "next/link";
 
 const RegisterForm = () => {
   const [state, formAction, pending] = useActionState(register, null);
@@ -19,52 +20,69 @@ const RegisterForm = () => {
   }, [state]);
 
   return (
-    <>
-      <form action={formAction}>
-        <div className="form-field">
-          <label htmlFor="username">ユーザー名</label>
-          <input
-            id="username"
-            name="username"
-            type="text"
-            required
-            disabled={pending}
-          />
-        </div>
-
-        <div className="form-field">
-          <label htmlFor="email">メールアドレス</label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            required
-            disabled={pending}
-          />
-        </div>
-
-        <div className="form-field">
-          <label htmlFor="password">パスワード</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            required
-            disabled={pending}
-          />
-        </div>
-
-        <button type="submit" disabled={pending} className="submit-button">
-          {pending ? "登録中..." : "登録する"}
-        </button>
-
-        {state?.error && (
-          <div className="error-message">
-            <p>エラーが発生しました：{state.error}</p>
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl w-full max-w-sm p-6 flex flex-col gap-3">
+        <form action={formAction}>
+          <div className="flex flex-col gap-3">
+            <h1 className="flex text-xl font-serif justify-center">
+              ユーザ登録
+            </h1>
+            <div className="flex flex-col">
+              <label htmlFor="username">ユーザー名</label>
+              <input
+                id="username"
+                name="username"
+                type="text"
+                required
+                disabled={pending}
+                className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+              />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="email">メールアドレス</label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                disabled={pending}
+                className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+              />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="password">パスワード</label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                disabled={pending}
+                className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-gray-400"
+              />
+            </div>
+            <div className="mt-2 flex justify-center">
+              <button
+                type="submit"
+                disabled={pending}
+                className="rounded-lg py-2 px-3 bg-gray-900 text-gray-100 text-lg font-serif shadow-md hover:bg-gray-700 transition-colors duration-300 cursor-pointer"
+              >
+                {pending ? "登録中..." : "登録する"}
+              </button>
+            </div>
+            {state?.error && (
+              <div className="error-message">
+                <p>エラーが発生しました：{state.error}</p>
+              </div>
+            )}
           </div>
-        )}
-      </form>
-    </>
+        </form>
+        <div className="mt-2 flex justify-center">
+          <button className="rounded-lg py-2 px-3 border border-gray-200 text-lg font-serif text-gray-600 hover:bg-gray-50 transition-colors duration-300 cursor-pointer">
+            <Link href={`/login`}>ログインへ戻る</Link>
+          </button>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/app/components/RegisterForm.tsx
+++ b/app/components/RegisterForm.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { register } from "../actions";
+
+const RegisterForm = () => {
+  const [state, formAction, pending] = useActionState(register, null);
+
+  useEffect(() => {
+    if (!state) {
+      return;
+    }
+
+    if (state.status === "success") {
+      alert(JSON.stringify(state.data));
+    } else if (state.status === "error") {
+      alert(state.error);
+    }
+  }, [state]);
+
+  return (
+    <>
+      <form action={formAction}>
+        <div className="form-field">
+          <label htmlFor="username">ユーザー名</label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            required
+            disabled={pending}
+          />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            disabled={pending}
+          />
+        </div>
+
+        <div className="form-field">
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            disabled={pending}
+          />
+        </div>
+
+        <button type="submit" disabled={pending} className="submit-button">
+          {pending ? "登録中..." : "登録する"}
+        </button>
+
+        {state?.error && (
+          <div className="error-message">
+            <p>エラーが発生しました：{state.error}</p>
+          </div>
+        )}
+      </form>
+    </>
+  );
+};
+
+export default RegisterForm;

--- a/app/constants/ui.ts
+++ b/app/constants/ui.ts
@@ -18,6 +18,7 @@ export const buttonConfig = {
   delete: "削除",
   want: "行きたい",
   done: "行った",
+  logout: "ログアウト",
 };
 
 export const toggleConfig = {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,26 @@
+import { titleConfig } from "@/app/constants/ui";
+import LoginForm from "@/app/components/LoginForm";
+import Link from "next/link";
+
+const LoginPage = async () => {
+  return (
+    <div className="mx-auto px-4 py-6 md:px-8">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-semibold font-serif text-gray-900">
+          {titleConfig.title}
+        </h1>
+      </div>
+      <div className="flex justify-end">
+        <div className="mb-4 mr-1 hidden md:block">
+          <h1>ログイン</h1>
+          <LoginForm />
+          <button>
+            <Link href={`/register`}>新規登録</Link>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,5 @@
 import { titleConfig } from "@/app/constants/ui";
 import LoginForm from "@/app/components/LoginForm";
-import Link from "next/link";
 
 const LoginPage = async () => {
   return (
@@ -11,12 +10,8 @@ const LoginPage = async () => {
         </h1>
       </div>
       <div className="flex justify-end">
-        <div className="mb-4 mr-1 hidden md:block">
-          <h1>ログイン</h1>
+        <div className="mb-4 mr-1">
           <LoginForm />
-          <button>
-            <Link href={`/register`}>新規登録</Link>
-          </button>
         </div>
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { getTrips } from "@/lib/api";
 import TripListTabs from "@/app/components/TripListTabs";
 import AddTripModal from "@/app/components/AddTripModal";
 import { titleConfig } from "@/app/constants/ui";
-import { LogoutButton } from "./components/LogoutButton";
+import { LogoutButton } from "@/app/components/LogoutButton";
 
 const Page = async () => {
   const trips = await getTrips();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import { getTrips } from "@/lib/api";
 import TripListTabs from "@/app/components/TripListTabs";
 import AddTripModal from "@/app/components/AddTripModal";
 import { titleConfig } from "@/app/constants/ui";
+import { LogoutButton } from "./components/LogoutButton";
 
 const Page = async () => {
   const trips = await getTrips();
@@ -13,12 +14,13 @@ const Page = async () => {
         <h1 className="text-3xl font-semibold font-serif text-gray-900">
           {titleConfig.title}
         </h1>
-        <span className="text-xs text-gray-500">
-          達成率{" "}
-          {trips.length > 0 ? Math.round((doneCount / trips.length) * 100) : 0}%
-          · {doneCount} / {trips.length}件
-        </span>
+        <LogoutButton />
       </div>
+      <span className="my-2 flex text-xs text-gray-500 justify-end">
+        達成率{" "}
+        {trips.length > 0 ? Math.round((doneCount / trips.length) * 100) : 0}% ·{" "}
+        {doneCount} / {trips.length}件
+      </span>
       <div className="flex justify-end">
         <div className="mb-4 mr-1 hidden md:block">
           <AddTripModal />

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,22 @@
+import { titleConfig } from "@/app/constants/ui";
+import RegisterForm from "../components/RegisterForm";
+
+const RegisterPage = async () => {
+  return (
+    <div className="mx-auto px-4 py-6 md:px-8">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-semibold font-serif text-gray-900">
+          {titleConfig.title}
+        </h1>
+      </div>
+      <div className="flex justify-end">
+        <div className="mb-4 mr-1 hidden md:block">
+          <h1>ユーザ登録</h1>
+          <RegisterForm />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,5 +1,5 @@
 import { titleConfig } from "@/app/constants/ui";
-import RegisterForm from "../components/RegisterForm";
+import RegisterForm from "@/app/components/RegisterForm";
 
 const RegisterPage = async () => {
   return (
@@ -10,7 +10,7 @@ const RegisterPage = async () => {
         </h1>
       </div>
       <div className="flex justify-end">
-        <div className="mb-4 mr-1 hidden md:block">
+        <div className="mb-4 mr-1">
           <h1>ユーザ登録</h1>
           <RegisterForm />
         </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,15 +1,24 @@
-import type { Trip, TripDetail } from "./types";
+import type { Trip, TripDetail } from "@/lib/types";
+import { getAuthHeader } from "@/lib/auth";
 
 const API_BASE = process.env.API_URL ?? "http://localhost:8000";
 
+// 旅行の全件表示
 export const getTrips = async (): Promise<Trip[]> => {
-  const res = await fetch(`${API_BASE}/trips`, { cache: "no-store" });
+  const res = await fetch(`${API_BASE}/trips`, {
+    cache: "no-store",
+    headers: await getAuthHeader(),
+  });
   if (!res.ok) throw new Error("Failed to fetch trips");
   return res.json();
 };
 
+// 旅行の一件表示
 export const getTrip = async (id: number): Promise<TripDetail> => {
-  const res = await fetch(`${API_BASE}/trips/${id}`, { cache: "no-store" });
+  const res = await fetch(`${API_BASE}/trips/${id}`, {
+    cache: "no-store",
+    headers: await getAuthHeader(),
+  });
   if (!res.ok) throw new Error("Failed to fetch trip");
   return res.json();
 };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,8 @@
+import { cookies } from "next/headers";
+
+// アクセストークンの取得（ログイン確認）
+export const getAuthHeader = async (): Promise<Record<string, string>> => {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("accessToken")?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get("accessToken");
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+  return NextResponse.next();
+}
+
+// /loginと/registerは除外
+export const config = {
+  matcher: ["/((?!login|register|_next).*)"],
+};


### PR DESCRIPTION
## 概要
認証画面を追加した。

## 実装した画面
- [x] ログイン画面
- [x] ユーザ登録画面

## 実装コンポーネント
- ログインフォーム
- ユーザ登録フォーム
- ログアウトボタン 

## 実装処理
- サーバーアクション(ログイン・ユーザ登録・ログアウト) 
- 既存のサーバーアクション処理内でアクセストークンを要求(=ログイン状態かどうか確認)するように変更
- アクセストークン取得処理 
- middleware.ts(ページ遷移時にログイン状態かどうか確認・必要に応じログイン画面へ遷移)

## 動作確認
- [x] バックエンドとの結合動作確認

Closes #25 